### PR TITLE
chore(ci): run CI on merge_group events

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,11 +4,10 @@ on:
   pull_request:
     branches:
       - main
-      - master
+  merge_group:
   push:
     branches:
       - main
-      - master
     tags:
       - v*
 env:


### PR DESCRIPTION
This allows the merge queue feature to work.