### PR TITLE
Upgraded dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
       - name: Download dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ on:
 env:
   CGO_ENABLED: '0'
   # renovate: datasource=github-releases depName=golangci/golangci-lint versioning=semver-coerced
-  GOLANGCI_LINT_VERSION: "v1.64.8"
+  GOLANGCI_LINT_VERSION: "v2.11.4"
   # renovate: datasource=github-releases depName=goreleaser/goreleaser versioning=semver-coerced
   GORELEASER_VERSION: "v2.15.4"
 jobs:

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/retailnext/sentry-sendmail
 
 go 1.23
 
-toolchain go1.24.6
+toolchain go1.26.2
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/sendmail.go
+++ b/sendmail.go
@@ -53,16 +53,16 @@ func SentryConfig() error {
 
 	// Error parsing the config file and we still don't have a DSN
 	if _, isFileErr := err.(*os.PathError); conf.SentryDSN == "" && err != nil && !isFileErr {
-		return fmt.Errorf("Can not read Sentry DSN from %s: %v", configPath, err)
+		return fmt.Errorf("can not read Sentry DSN from %s: %v", configPath, err)
 	}
 
 	if conf.SentryDSN == "" {
-		return fmt.Errorf("Sentry DSN not set. Please set SENTRY_DSN environment variable or enter DSN in the config file: %s", configPath)
+		return fmt.Errorf("sentry DSN not set. Please set SENTRY_DSN environment variable or enter DSN in the config file: %s", configPath)
 	}
 
 	err = raven.SetDSN(conf.SentryDSN)
 	if err != nil {
-		return fmt.Errorf("Sentry DSN [%s] error: %v", conf.SentryDSN, err)
+		return fmt.Errorf("sentry DSN [%s] error: %v", conf.SentryDSN, err)
 	}
 
 	if conf.Environment != "" {
@@ -88,7 +88,7 @@ func SentrySend(message string, headers map[string]string) error {
 		err := <-ch
 		return err
 	}
-	return fmt.Errorf("Capture returned empty eventID")
+	return fmt.Errorf("capture returned empty eventID")
 }
 
 // ReadData reads data envelope from an input stream and parses the message.
@@ -100,8 +100,8 @@ func ReadData(reader *bufio.Reader) (map[string]string, string, string) {
 	var logFile *os.File
 	if opts.LogFile != "" {
 		logFile, _ = os.OpenFile(opts.LogFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-		fmt.Fprintln(logFile, time.Now().UTC().Format("2006-01-02T15:04:05.999Z"), "-----------")
-		defer logFile.Close()
+		_, _ = fmt.Fprintln(logFile, time.Now().UTC().Format("2006-01-02T15:04:05.999Z"), "-----------")
+		defer func() { _ = logFile.Close()}()
 	}
 
 	// Read headers first
@@ -111,7 +111,7 @@ func ReadData(reader *bufio.Reader) (map[string]string, string, string) {
 	for {
 		line, err := reader.ReadString('\n')
 		if logFile != nil {
-			fmt.Fprint(logFile, line)
+			_, _ = fmt.Fprint(logFile, line)
 		}
 		raw += line
 		if err != nil {
@@ -166,7 +166,7 @@ func BuildMessage(headers map[string]string, body string) (string, error) {
 		headers["from"] = opts.SenderAddress
 	}
 	if len(headers["from"]) == 0 {
-		return message, fmt.Errorf("Sender must be specified")
+		return message, fmt.Errorf("sender must be specified")
 	}
 
 	if headers["content-transfer-encoding"] == "quoted-printable" {


### PR DESCRIPTION
These dependencies are so outdated that cannot be updated separtely:
* current golangci-lint cannot analyse go1.26
* current action cannot setup golangci-lint v2
* latest action requires golangci-lint v2

Also latest golagnci-lint compains about error handling in the code, this is also addressed now